### PR TITLE
Handle multipart/alternative messages

### DIFF
--- a/src/main/java/de/gessnerfl/fakesmtp/model/ContentType.java
+++ b/src/main/java/de/gessnerfl/fakesmtp/model/ContentType.java
@@ -1,5 +1,11 @@
 package de.gessnerfl.fakesmtp.model;
 
 public enum ContentType {
-    HTML, PLAIN
+    HTML, PLAIN, MULTIPART_ALTERNATIVE;
+
+    public static ContentType fromString(String string) {
+        if (string.startsWith("multipart/alternative")) return MULTIPART_ALTERNATIVE;
+        if (string.startsWith("text/html")) return HTML;
+        return PLAIN;
+    }
 }

--- a/src/main/java/de/gessnerfl/fakesmtp/model/Email.java
+++ b/src/main/java/de/gessnerfl/fakesmtp/model/Email.java
@@ -121,4 +121,58 @@ public class Email {
     public int hashCode() {
         return id.hashCode();
     }
+
+    public static class Builder {
+        private String fromAddress;
+        private String toAddress;
+        private Date receivedOn;
+        private String subject;
+        private String rawData;
+        private String content;
+        private ContentType contentType;
+
+        public Builder fromAddress(String fromAddress) {
+            this.fromAddress = fromAddress;
+            return this;
+        }
+        public Builder toAddress(String toAddress) {
+            this.toAddress = toAddress;
+            return this;
+        }
+        public Builder receivedOn(Date receivedOn) {
+            this.receivedOn = receivedOn;
+            return this;
+        }
+        public Builder subject(String subject) {
+            this.subject = subject;
+            return this;
+        }
+        public Builder rawData(String rawData) {
+            this.rawData = rawData;
+            return this;
+        }
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+        public Builder contentType(ContentType contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public Email build() {
+            Email email = new Email();
+            email.setFromAddress(this.fromAddress);
+            email.setToAddress(this.toAddress);
+            email.setReceivedOn(this.receivedOn);
+            email.setSubject(this.subject);
+            email.setRawData(this.rawData);
+            if (this.content != null && !this.content.isEmpty())
+                email.setContent(this.content);
+            else
+                email.setContent(this.rawData);
+            email.setContentType(this.contentType);
+            return email;
+        }
+    }
 }

--- a/src/test/java/de/gessnerfl/fakesmtp/server/EmailFactoryTest.java
+++ b/src/test/java/de/gessnerfl/fakesmtp/server/EmailFactoryTest.java
@@ -131,4 +131,64 @@ public class EmailFactoryTest {
         assertEquals(now, result.getReceivedOn());
         assertEquals(ContentType.PLAIN, result.getContentType());
     }
+
+    @Test
+    public void shouldCreateMailForMultipartWithContentTypeHtml() throws Exception {
+        Date now = new Date();
+        String testFilename = "multipart-mail.eml";
+        InputStream data = TestResourceUtil.getTestFile(testFilename);
+        String rawData = TestResourceUtil.getTestFileContent(testFilename);
+
+        when(timestampProvider.now()).thenReturn(now);
+
+        Email result = sut.convert(SENDER, RECEIVER, data);
+
+        assertEquals(SENDER, result.getFromAddress());
+        assertEquals(RECEIVER, result.getToAddress());
+        assertEquals("This is the mail title", result.getSubject());
+        assertEquals(rawData, result.getRawData());
+        assertEquals("<html><head></head><body>Mail Body</body></html>", result.getContent());
+        assertEquals(now, result.getReceivedOn());
+        assertEquals(ContentType.HTML, result.getContentType());
+    }
+
+    @Test
+    public void shouldCreateMailForMultipartWithoutContentTypeHtml() throws Exception {
+        Date now = new Date();
+        String testFilename = "multipart-mail-plain-only.eml";
+        InputStream data = TestResourceUtil.getTestFile(testFilename);
+        String rawData = TestResourceUtil.getTestFileContent(testFilename);
+
+        when(timestampProvider.now()).thenReturn(now);
+
+        Email result = sut.convert(SENDER, RECEIVER, data);
+
+        assertEquals(SENDER, result.getFromAddress());
+        assertEquals(RECEIVER, result.getToAddress());
+        assertEquals("This is the mail title", result.getSubject());
+        assertEquals(rawData, result.getRawData());
+        assertEquals("This is the message content", result.getContent());
+        assertEquals(now, result.getReceivedOn());
+        assertEquals(ContentType.PLAIN, result.getContentType());
+    }
+
+    @Test
+    public void shouldCreateMailForMultipartWithUnknownContentType() throws Exception {
+        Date now = new Date();
+        String testFilename = "multipart-mail-unknown-content-type.eml";
+        InputStream data = TestResourceUtil.getTestFile(testFilename);
+        String rawData = TestResourceUtil.getTestFileContent(testFilename);
+
+        when(timestampProvider.now()).thenReturn(now);
+
+        Email result = sut.convert(SENDER, RECEIVER, data);
+
+        assertEquals(SENDER, result.getFromAddress());
+        assertEquals(RECEIVER, result.getToAddress());
+        assertEquals("This is the mail title", result.getSubject());
+        assertEquals(rawData, result.getRawData());
+        assertEquals("This is the message content", result.getContent());
+        assertEquals(now, result.getReceivedOn());
+        assertEquals(ContentType.PLAIN, result.getContentType());
+    }
 }

--- a/src/test/resources/test-data/multipart-mail-plain-only.eml
+++ b/src/test/resources/test-data/multipart-mail-plain-only.eml
@@ -1,0 +1,33 @@
+mail-with-subject.emlDelivered-To: receiver@example.com
+Received: by 10.100.155.4 with SMTP id 987654328765;
+        Mon, 8 May 2017 02:12:12 -0700 (PDT)
+X-Received: by 10.223.133.200 with SMTP id 0987654387698.65.098765443543;
+        Mon, 08 May 2017 02:12:12 -0700 (PDT)
+Return-Path: <sender@example.com>
+Received: from host.example.com
+Received-SPF: pass (example.com: domain of sender@example.com designates 123.123.123.123 as permitted sender) client-ip=123.123.123.123;
+Authentication-Results: mx.example.com;
+       dkim=pass header.i=@example.com;
+       spf=pass (example.com: domain of sender@example.com designates 123.123.123.123 as permitted sender) smtp.mailfrom=sender@example.com
+Received: from proxy.example.com ([234.234.234.234]:12345 helo=Authentication)
+	by ns1.example.com with esmtpa (Exim 4.89)
+	(envelope-from <sender@example.com>)
+	id 123456-123456-12
+	for receiver@example.com; Mon, 08 May 2017 11:12:07 +0200
+From: "Sender" <sender@example.com>
+To: "'Receiver'" <receiver@example.com>
+References: <2323232323-2323-2323-2323-232323232323@example.com>
+In-Reply-To: <2323232323-2323-2323-2323-2323232323239@example.com>
+Subject: This is the mail title
+Date: Mon, 8 May 2017 11:12:09 +0200
+Message-ID: <772437572438758852084$@com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+    boundary="----=_Part_8_1062932675.1510577328078"
+
+------=_Part_8_1062932675.1510577328078
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+This is the message content
+------=_Part_8_1062932675.1510577328078--

--- a/src/test/resources/test-data/multipart-mail-unknown-content-type.eml
+++ b/src/test/resources/test-data/multipart-mail-unknown-content-type.eml
@@ -1,0 +1,36 @@
+mail-with-subject.emlDelivered-To: receiver@example.com
+Received: by 10.100.155.4 with SMTP id 987654328765;
+        Mon, 8 May 2017 02:12:12 -0700 (PDT)
+X-Received: by 10.223.133.200 with SMTP id 0987654387698.65.098765443543;
+        Mon, 08 May 2017 02:12:12 -0700 (PDT)
+Return-Path: <sender@example.com>
+Received: from host.example.com
+Received-SPF: pass (example.com: domain of sender@example.com designates 123.123.123.123 as permitted sender) client-ip=123.123.123.123;
+Authentication-Results: mx.example.com;
+       dkim=pass header.i=@example.com;
+       spf=pass (example.com: domain of sender@example.com designates 123.123.123.123 as permitted sender) smtp.mailfrom=sender@example.com
+Received: from proxy.example.com ([234.234.234.234]:12345 helo=Authentication)
+	by ns1.example.com with esmtpa (Exim 4.89)
+	(envelope-from <sender@example.com>)
+	id 123456-123456-12
+	for receiver@example.com; Mon, 08 May 2017 11:12:07 +0200
+From: "Sender" <sender@example.com>
+To: "'Receiver'" <receiver@example.com>
+References: <2323232323-2323-2323-2323-232323232323@example.com>
+In-Reply-To: <2323232323-2323-2323-2323-2323232323239@example.com>
+Subject: This is the mail title
+Date: Mon, 8 May 2017 11:12:09 +0200
+Message-ID: <772437572438758852084$@com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+    boundary="----=_Part_8_1062932675.1510577328078"
+
+------=_Part_8_1062932675.1510577328078
+Content-Transfer-Encoding: 7bit
+
+This is the message content
+------=_Part_8_1062932675.1510577328078
+Content-Transfer-Encoding: quoted-printable
+
+This is the message content
+------=_Part_8_1062932675.1510577328078--

--- a/src/test/resources/test-data/multipart-mail.eml
+++ b/src/test/resources/test-data/multipart-mail.eml
@@ -1,0 +1,38 @@
+mail-with-subject.emlDelivered-To: receiver@example.com
+Received: by 10.100.155.4 with SMTP id 987654328765;
+        Mon, 8 May 2017 02:12:12 -0700 (PDT)
+X-Received: by 10.223.133.200 with SMTP id 0987654387698.65.098765443543;
+        Mon, 08 May 2017 02:12:12 -0700 (PDT)
+Return-Path: <sender@example.com>
+Received: from host.example.com
+Received-SPF: pass (example.com: domain of sender@example.com designates 123.123.123.123 as permitted sender) client-ip=123.123.123.123;
+Authentication-Results: mx.example.com;
+       dkim=pass header.i=@example.com;
+       spf=pass (example.com: domain of sender@example.com designates 123.123.123.123 as permitted sender) smtp.mailfrom=sender@example.com
+Received: from proxy.example.com ([234.234.234.234]:12345 helo=Authentication)
+	by ns1.example.com with esmtpa (Exim 4.89)
+	(envelope-from <sender@example.com>)
+	id 123456-123456-12
+	for receiver@example.com; Mon, 08 May 2017 11:12:07 +0200
+From: "Sender" <sender@example.com>
+To: "'Receiver'" <receiver@example.com>
+References: <2323232323-2323-2323-2323-232323232323@example.com>
+In-Reply-To: <2323232323-2323-2323-2323-2323232323239@example.com>
+Subject: This is the mail title
+Date: Mon, 8 May 2017 11:12:09 +0200
+Message-ID: <772437572438758852084$@com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+    boundary="----=_Part_8_1062932675.1510577328078"
+
+------=_Part_8_1062932675.1510577328078
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+This is the message content
+------=_Part_8_1062932675.1510577328078
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<html><head></head><body>Mail Body</body></html>
+------=_Part_8_1062932675.1510577328078--


### PR DESCRIPTION
Hi,

This fake SMTP server is a nice tool for quick test sending emails :)
And, IMOO, a must have at demo time.

Here is a suggestion to:
- handle messages with content of type 'multipart/alternative'
- prefer the body part with content of type 'text/html'
- otherwise, choose the last read one

As a consequence, emails sent by systems to cover rich and basic email clients are rendered correctly in the Web UI.

Congratulations for the work done,

Hope to help,

Regards,
Guillaume