### PR TITLE
Force java version to 8u181 to autodetect container limits.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8u181-jdk-alpine
 
 VOLUME /tmp
 


### PR DESCRIPTION
With reference to issue #12, here is a pull request that forces the java version to 8u181 to handle memory limits in containers.