### PR TITLE
Render newlines in plain e-mail view

### DIFF
--- a/src/main/resources/static/customizing.css
+++ b/src/main/resources/static/customizing.css
@@ -31,3 +31,7 @@
 form.inline {
     display: inline
 }
+
+.mail-content-plain {
+    white-space: pre-line;
+}

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -41,7 +41,7 @@
                     </ul>
                 </div>
                 <div class="card-content">
-                    <div th:each="c,is : ${mail.contents}" th:id="'mail-content-'+${c.id}" th:utext="${c.data}"></div>
+                    <div th:each="c,is : ${mail.contents}" th:id="'mail-content-'+${c.id}" th:utext="${c.data}" class="mail-content-plain"></div>
                     <div id="mail-content-raw" class="grey lighten-4">
                         <pre class="card-content" th:text="${mail.rawData}"></pre>
                     </div>


### PR DESCRIPTION
These CSS styles display newlines in plain text e-mail message in the browser. Without `pre-line` the paragraphs separated by `\n` are displayed as a single long text in the browser GUI.