### PR TITLE
Resize iframe for HTML messages to match content height

### DIFF
--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -34,8 +34,8 @@
                     </ul>
                     <div class="tab-content p-3" id="mail-tabs-content">
                         <div class="tab-pane fade mail-content-plain position-relative" th:each="c,is : ${mail.contents}" th:id="'mail-content-'+${c.id}" th:classappend="${is.first} ? 'show active' : ''">
-                            <div th:if="${c.contentType == T(de.gessnerfl.fakesmtp.model.ContentType).PLAIN}" class="position-absolute top-0 start-0 w-100" th:text="${c.data}"></div>
-                            <iframe th:unless="${c.contentType == T(de.gessnerfl.fakesmtp.model.ContentType).PLAIN}" class="position-absolute top-0 start-0 w-100 h-100" th:attr="srcdoc=${@htmlContentRenderer.render(c)}" sandbox></iframe>
+                            <div th:if="${c.contentType == T(de.gessnerfl.fakesmtp.model.ContentType).PLAIN}" class="w-100" th:text="${c.data}"></div>
+                            <iframe th:unless="${c.contentType == T(de.gessnerfl.fakesmtp.model.ContentType).PLAIN}" class="w-100" th:attr="srcdoc=${@htmlContentRenderer.render(c)}" sandbox="allow-same-origin" onload="resizeIframe(this)"></iframe>
                         </div>
                         <div class="tab-pane fade" id="mail-content-raw">
                             <pre class="card-content" th:text="${mail.rawData}"></pre>

--- a/src/main/resources/templates/fragments/html-header.html
+++ b/src/main/resources/templates/fragments/html-header.html
@@ -7,6 +7,12 @@
 
     <script type="text/javascript" th:src="@{/webjars/bootstrap/5.2.0/js/bootstrap.bundle.min.js}"></script>
 
+    <script type="text/javascript">
+        function resizeIframe(iframe) {
+            iframe.style.height = iframe.contentWindow.document.documentElement.scrollHeight + 'px';
+        }
+    </script>
+
     <title>Fake SMTP Server</title>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />


### PR DESCRIPTION
The h-100 doesn't really work with <iframe>. Instead, need to use JavaScript to resize the height of the iframe to match the content height.

Need to set `sandbox="allow-same-origin"` to get around `Uncaught DOMException: Permission denied to access property "document" on cross-origin object`