### PR TITLE
Paginate api response

### DIFF
--- a/src/main/java/de/gessnerfl/fakesmtp/controller/EmailRestController.java
+++ b/src/main/java/de/gessnerfl/fakesmtp/controller/EmailRestController.java
@@ -4,17 +4,18 @@ import de.gessnerfl.fakesmtp.model.Email;
 import de.gessnerfl.fakesmtp.repository.EmailAttachmentRepository;
 import de.gessnerfl.fakesmtp.repository.EmailRepository;
 import de.gessnerfl.fakesmtp.util.MediaTypeUtil;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.ServletContext;
-import javax.validation.constraints.Min;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,8 +23,6 @@ import java.util.List;
 @RequestMapping("/api")
 @Validated
 public class EmailRestController {
-
-    private static final int DEFAULT_PAGE_SIZE = 10;
 
     private static final String DEFAULT_SORT_PROPERTY = "receivedOn";
 
@@ -41,10 +40,9 @@ public class EmailRestController {
     }
 
     @GetMapping("/email")
-    public List<Email> all(@RequestParam(value = "page", defaultValue = "0") @Min(0) int page,
-                           @RequestParam(value = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) @Min(0) int size,
-                           @RequestParam(value = "sort", defaultValue = "DESC") Sort.Direction sort) {
-        var result = emailRepository.findAll(PageRequest.of(page, size, Sort.by(sort, DEFAULT_SORT_PROPERTY)));
+    public List<Email> all(@SortDefault.SortDefaults({@SortDefault(sort = DEFAULT_SORT_PROPERTY, direction = Sort.Direction.DESC)}) Pageable pageable) 
+    {
+        var result = emailRepository.findAll(pageable);
         if (result.getNumber() != 0 && result.getNumber() >= result.getTotalPages()) {
             return Collections.emptyList();
         }

--- a/src/main/java/de/gessnerfl/fakesmtp/controller/EmailRestController.java
+++ b/src/main/java/de/gessnerfl/fakesmtp/controller/EmailRestController.java
@@ -7,6 +7,7 @@ import de.gessnerfl.fakesmtp.util.MediaTypeUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
@@ -16,8 +17,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.ServletContext;
-import java.util.Collections;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -40,13 +39,9 @@ public class EmailRestController {
     }
 
     @GetMapping("/email")
-    public List<Email> all(@SortDefault.SortDefaults({@SortDefault(sort = DEFAULT_SORT_PROPERTY, direction = Sort.Direction.DESC)}) Pageable pageable) 
+    public Page<Email> all(@SortDefault.SortDefaults({@SortDefault(sort = DEFAULT_SORT_PROPERTY, direction = Sort.Direction.DESC)}) Pageable pageable) 
     {
-        var result = emailRepository.findAll(pageable);
-        if (result.getNumber() != 0 && result.getNumber() >= result.getTotalPages()) {
-            return Collections.emptyList();
-        }
-        return result.getContent();
+        return emailRepository.findAll(pageable);
     }
 
     @GetMapping("/email/{id}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,12 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.mvc.hiddenmethod.filter.enabled=true
 spring.h2.console.enabled=true
 
+spring.data.web.pageable.size-parameter=size
+spring.data.web.pageable.page-parameter=page
+spring.data.web.pageable.default-page-size=10
+spring.data.web.pageable.one-indexed-parameters=false
+spring.data.web.pageable.max-page-size=1000
+
 springdoc.swagger-ui.path=/swagger-ui.html
 
 fakesmtp.port=5025

--- a/src/test/java/de/gessnerfl/fakesmtp/controller/EmailRestControllerTest.java
+++ b/src/test/java/de/gessnerfl/fakesmtp/controller/EmailRestControllerTest.java
@@ -52,7 +52,7 @@ class EmailRestControllerTest {
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(emailRepository).findAll(pageableCaptor.capture());
         assertEquals(pageableCaptor.getValue(), pageable);
-        assertEquals(page.getContent(), result);
+        assertEquals(page, result);
         verifyNoMoreInteractions(emailRepository);
     }
 

--- a/src/test/java/de/gessnerfl/fakesmtp/controller/EmailRestControllerTest.java
+++ b/src/test/java/de/gessnerfl/fakesmtp/controller/EmailRestControllerTest.java
@@ -7,11 +7,13 @@ import de.gessnerfl.fakesmtp.repository.EmailRepository;
 import de.gessnerfl.fakesmtp.util.MediaTypeUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
@@ -43,11 +45,14 @@ class EmailRestControllerTest {
     void shouldReturnListOfEmails() {
         final Page<Email> page = createFirstPageEmail();
         when(emailRepository.findAll(any(Pageable.class))).thenReturn(page);
+        
+        var pageable = PageRequest.of(0, 5, Sort.Direction.DESC, "receivedOn");
+        var result = sut.all(pageable);
 
-        var result = sut.all(0, 5, Sort.Direction.DESC);
-
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(emailRepository).findAll(pageableCaptor.capture());
+        assertEquals(pageableCaptor.getValue(), pageable);
         assertEquals(page.getContent(), result);
-        verify(emailRepository).findAll(argThat(matchPageable(0, 5)));
         verifyNoMoreInteractions(emailRepository);
     }
 
@@ -65,7 +70,8 @@ class EmailRestControllerTest {
 
     private Page<Email> createFirstPageEmail() {
         var page = mock(Page.class);
-        when(page.getNumber()).thenReturn(0);
+        //when(page.getNumber()).thenReturn(0);
+        //when(page.getPageable()).thenReturn(PageRequest.of(0, pageSize));
         return page;
     }
 

--- a/src/test/java/de/gessnerfl/fakesmtp/controller/EmailRestControllerTest.java
+++ b/src/test/java/de/gessnerfl/fakesmtp/controller/EmailRestControllerTest.java
@@ -70,13 +70,7 @@ class EmailRestControllerTest {
 
     private Page<Email> createFirstPageEmail() {
         var page = mock(Page.class);
-        //when(page.getNumber()).thenReturn(0);
-        //when(page.getPageable()).thenReturn(PageRequest.of(0, pageSize));
         return page;
-    }
-
-    private ArgumentMatcher<Pageable> matchPageable(int page, int size) {
-        return (item) -> item.getPageNumber() == page && item.getPageSize() == size;
     }
 
     @Test

--- a/src/test/java/de/gessnerfl/fakesmtp/model/RestResponsePage.java
+++ b/src/test/java/de/gessnerfl/fakesmtp/model/RestResponsePage.java
@@ -1,0 +1,20 @@
+package de.gessnerfl.fakesmtp.model;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class RestResponsePage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestResponsePage(@JsonProperty("content") List<T> content, @JsonProperty("number") int number, @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") Long totalElements, @JsonProperty("pageable") JsonNode pageable, @JsonProperty("last") boolean last,
+                    @JsonProperty("totalPages") int totalPages, @JsonProperty("sort") JsonNode sort, @JsonProperty("first") boolean first,
+                    @JsonProperty("numberOfElements") int numberOfElements, @JsonProperty("empty") boolean empty) {
+        super(content, PageRequest.of(number, size), totalElements);
+    }
+}


### PR DESCRIPTION
On the one hand you can infer the pagination arguments in the controller using the spring paging configuration with Pageable argument ([here](https://reflectoring.io/spring-boot-paging) you can see something interesting about it).

On the other hand, GET paginated emails endpoint should return (at least) information on the total number of pages. If from an external client you try to get page 1 with 10 elements, currently you can receive a list of 10 elements, but you don't know if there are more pages, how many there are, etc. A paged endpoint should always return item count information to allow the client to display the number of pages, item counts, etc.