### PR TITLE
#147: Fix hosting webapp on relative path

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -39,6 +39,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "homepage": ".",
   "proxy": "http://localhost:8080",
   "eslintConfig": {
     "extends": [

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="base-path" content="/">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Fake SMTP Server - SMTP Server which stores all received emails in an in-memory database and renders the emails in a web interface"

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -13,10 +13,9 @@ export function getBasePath() {
 }
 
 function resolveBasePath() {
-    const attr = document.querySelector("meta[name='base-path']")?.getAttribute("content");
-    if (attr) {
-        const normalized = attr.endsWith("/") ? attr.slice(0, -1) : attr;
-        return normalized.length > 0 ? normalized : undefined
+    const path = window.location.pathname;
+    if (path) {
+        return path.substring(0, path.lastIndexOf("/"));
     }
     return undefined
 }


### PR DESCRIPTION
See #147 

Changes for 2.0.1 did not seem to fix the issue completely. This PR changes the following:

* Add `hompage` attribute to `package.json` (see https://create-react-app.dev/docs/deployment/#building-for-relative-paths)
* Remove `<meta name="base-path" content="/">` -> was used to determine relative path, but was hardcoded to `/`
* Resolve relative path by looking into `window.location.pathname` attribute instead of removed meta attribute